### PR TITLE
Fix aro lookup when parent is null

### DIFF
--- a/src/Controller/Component/AclManagerComponent.php
+++ b/src/Controller/Component/AclManagerComponent.php
@@ -156,7 +156,7 @@ class AclManagerComponent extends Component {
             ];
         } else {
             $conditions = [
-                'parent_id IS NULL',
+                'parent_id' => null,
                 'foreign_key' => $aro->foreign_key,
                 'model' => $aro->model
             ];


### PR DESCRIPTION
## Summary
- fix condition for ARO lookup when parent is null

## Testing
- `composer --version` *(fails: command not found)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe9dda0cc832995d1efdbb7756104

## Resumo por Sourcery

Correccións de erros:
- Substitúe a condición SQL 'parent_id IS NULL' por unha comparación de nulos baseada en arrays PHP para a busca de ARO

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Replace SQL 'parent_id IS NULL' condition with PHP array-based null comparison for ARO lookup

</details>